### PR TITLE
Handle missing category posts in library template

### DIFF
--- a/_layouts/library.html
+++ b/_layouts/library.html
@@ -21,7 +21,8 @@ layout: default
       <div class="dogear" aria-hidden="true"></div>
       <h3>{{ c.label }}</h3>
       <ul>
-        {% assign posts = site.categories[c.id] | sort: 'date' | reverse %}
+        {% assign posts = site.categories[c.id] | default: [] %}
+        {% assign posts = posts | sort: "date" | reverse %}
         {% if posts and posts.size > 0 %}
           {% for p in posts limit:3 %}
             <li>{{ p.title }}</li>


### PR DESCRIPTION
## Summary
- Safeguard library layout against missing categories
- Sort posts only after applying a default empty list

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a754ec72b08333b53367a76fa01ca0